### PR TITLE
fix(calendar): visual styling improvements for day selection

### DIFF
--- a/src/components/CalendarMonth.tsx
+++ b/src/components/CalendarMonth.tsx
@@ -50,7 +50,7 @@ const CalendarMonth: React.FC<CalendarMonthProps> = ({
           predictedOvulation: predictedOvulation
         }}
         modifiersClassNames={{
-          today: "[&_button]:border-2 [&_button]:border-slate-900 [&_button]:font-bold",
+          today: "[&_button]:border-2 [&_button]:border-slate-300 [&_button]:font-bold",
           period: "[&_button]:bg-rose-500 [&_button]:text-white",
           ovulation: "[&_button]:bg-violet-500 [&_button]:text-white",
           predicted: "[&_button]:border-2 [&_button]:border-dashed [&_button]:border-rose-300 [&_button]:text-rose-500 [&_button]:bg-rose-50",
@@ -58,7 +58,7 @@ const CalendarMonth: React.FC<CalendarMonthProps> = ({
         }}
         classNames={{
           month_grid: "w-full table-fixed",
-          day: "p-0",
+          day: "p-0.5",
           // Removed transition-colors to eliminate perceived lag on click
           day_button: "w-full aspect-square flex items-center justify-center rounded-full",
         }}


### PR DESCRIPTION
This PR addresses visual issues with the calendar day selection:
1. The current day highlight border was too intense (`slate-900`) against colored backgrounds, so it has been softened to `slate-300`.
2. Selected days were touching each other directly without any space. Padding (`p-0.5`) has been added to the day cells to create visual separation between adjacent selected dates.

Screenshots have been taken to verify the changes, and no regressions were introduced.

---
*PR created automatically by Jules for task [10290948522177683946](https://jules.google.com/task/10290948522177683946) started by @zhenyava*