### PR TITLE
feat: add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.1.0'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+
+  test:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.1.0'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run test
+
+  build:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.1.0'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,15 @@ describe('serviceName', () => {
 - **TypeScript**: Strict type checking
 - **No unused variables**: Enforce clean code
 
+### CI Pipeline
+
+A GitHub Actions workflow (`.github/workflows/ci.yml`) is set up to automatically run the following checks on every pull request to the `main` branch:
+1. `npm run lint` - static analysis
+2. `npm run test` - unit tests
+3. `npm run build` - build verification
+
+These checks are sequential and must pass before a PR can be merged.
+
 ### Before Committing
 1. Run `npm run lint` - fix all ESLint errors
 2. Run `npm run test` - ensure all tests pass


### PR DESCRIPTION
This PR introduces a GitHub Actions CI workflow as requested in issue #24.

- Adds `.github/workflows/ci.yml` that runs on pull requests to the `main` branch.
- Configures three sequential jobs: `lint`, `test`, and `build`.
- Uses Node.js v24.1.0 and `npm ci` for consistent installation.
- Updates `AGENTS.md` to document the new CI pipeline.

Closes #24.

---
*PR created automatically by Jules for task [12638346430679277088](https://jules.google.com/task/12638346430679277088) started by @zhenyava*