### PR TITLE
Fix visual layout and month size issue on calendar compression

### DIFF
--- a/src/components/CalendarMonth.tsx
+++ b/src/components/CalendarMonth.tsx
@@ -60,7 +60,7 @@ const CalendarMonth: React.FC<CalendarMonthProps> = ({
           month_grid: "w-full table-fixed",
           day: "p-0.5",
           // Removed transition-colors to eliminate perceived lag on click
-          day_button: "w-full aspect-square flex items-center justify-center rounded-full",
+          day_button: "w-full max-w-[40px] mx-auto aspect-square flex items-center justify-center rounded-full",
         }}
       />
     </div>

--- a/src/components/DesktopCalendarView.tsx
+++ b/src/components/DesktopCalendarView.tsx
@@ -48,17 +48,17 @@ export default function DesktopCalendarView({
             </div>
 
             {/* Months Grid (Single Year) */}
-            <div className="flex-1 min-h-0 flex justify-center items-center">
-                <div className="grid grid-cols-4 grid-rows-3 gap-x-6 gap-y-4 h-full w-auto max-w-full aspect-[4/3]">
+            <div className="flex-1 min-h-0 overflow-y-auto pr-2 pb-4">
+                <div className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-x-6 gap-y-6">
                     {months.map(month => (
-                        <div key={month.toString()} className="bg-white p-2 rounded-2xl shadow-sm border border-gray-100 flex flex-col justify-center">
+                        <div key={month.toString()} className="bg-white p-4 rounded-2xl shadow-sm border border-gray-100 flex flex-col justify-center">
                             <CalendarMonth 
                                 month={month} 
                                 events={events}
                                 predictedDates={predictedDates}
                                 predictedOvulationDates={predictedOvulationDates}
                                 onDayClick={onDayClick}
-                                className="h-full w-full"
+                                className="w-full"
                             />
                         </div>
                     ))}


### PR DESCRIPTION
This fixes issue #15 where the calendar days were spilling out of bounds when the browser window's height was compressed.

Changes:
- Removed strict `h-full` constraints from `DesktopCalendarView` wrapper and grids.
- Added `overflow-y-auto` to the parent container to gracefully handle narrow/short viewports by adding a vertical scrollbar instead of compressing the calendar grid.
- Added a `max-w-[40px]` rule alongside `mx-auto` for the individual date buttons (`day_button`) to prevent the aspect-square elements from scaling excessively large inside their flex containers.

Visual regressions are fixed and tests are passing.

---
*PR created automatically by Jules for task [263312761229172414](https://jules.google.com/task/263312761229172414) started by @zhenyava*