### PR TITLE
feat: implement data sharing via Google Drive

### DIFF
--- a/src/components/CalendarApp.tsx
+++ b/src/components/CalendarApp.tsx
@@ -49,7 +49,11 @@ function CalendarApp() {
     handleGoogleLogin,
     handleLogout,
     performFullSync,
-    driveFileId
+    driveFileId,
+    connectSharedFile,
+    disconnectSharedFile,
+    isSharedFile,
+    isSharedFileReadOnly
   } = useGoogleSync({ 
       events: allRecords, // Pass raw records for sync
       setEvents
@@ -128,6 +132,11 @@ function CalendarApp() {
         currentYear={currentYear}
         onPrevYear={handlePrevYear}
         onNextYear={handleNextYear}
+        driveFileId={driveFileId}
+        connectSharedFile={connectSharedFile}
+        disconnectSharedFile={disconnectSharedFile}
+        isSharedFile={isSharedFile}
+        isSharedFileReadOnly={isSharedFileReadOnly}
       />
 
       {/* Main Content Area */}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -28,6 +28,13 @@ interface HeaderProps {
     currentYear?: number;
     onPrevYear?: () => void;
     onNextYear?: () => void;
+
+    // Sharing Props
+    driveFileId: string | null;
+    connectSharedFile: (linkOrId: string) => void;
+    disconnectSharedFile: () => void;
+    isSharedFile: boolean;
+    isSharedFileReadOnly: boolean;
 }
 
 interface TypeToggleButtonProps {
@@ -71,7 +78,12 @@ export default function Header({
     setIsEditMode,
     currentYear,
     onPrevYear,
-    onNextYear
+    onNextYear,
+    driveFileId,
+    connectSharedFile,
+    disconnectSharedFile,
+    isSharedFile,
+    isSharedFileReadOnly
 }: HeaderProps) {
     const navigate = useNavigate();
 
@@ -197,6 +209,11 @@ export default function Header({
                 setGoogleClientId={setGoogleClientId}
                 onLogin={onLogin}
                 onLogout={onLogout}
+                driveFileId={driveFileId}
+                connectSharedFile={connectSharedFile}
+                disconnectSharedFile={disconnectSharedFile}
+                isSharedFile={isSharedFile}
+                isSharedFileReadOnly={isSharedFileReadOnly}
             />
         </header>
     );

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
-import { Cloud, MessageSquare, Settings } from 'lucide-react';
+import { Cloud, MessageSquare, Settings, Share2, Link as LinkIcon, Users, CheckCircle, AlertCircle } from 'lucide-react';
 import { FOLDER_NAME } from '../constants';
+import { shareDriveFile } from '../services/googleService';
 
 interface SettingsModalProps {
     isOpen: boolean;
@@ -10,6 +11,11 @@ interface SettingsModalProps {
     setGoogleClientId: (id: string) => void;
     onLogin: () => void;
     onLogout: () => void;
+    driveFileId: string | null;
+    connectSharedFile: (linkOrId: string) => void;
+    disconnectSharedFile: () => void;
+    isSharedFile: boolean;
+    isSharedFileReadOnly: boolean;
 }
 
 export default function SettingsModal({
@@ -18,15 +24,55 @@ export default function SettingsModal({
     googleClientId,
     setGoogleClientId,
     onLogin,
-    onLogout
+    onLogout,
+    driveFileId,
+    connectSharedFile,
+    disconnectSharedFile,
+    isSharedFile,
+    isSharedFileReadOnly
 }: SettingsModalProps) {
     const [showAdvancedConfig, setShowAdvancedConfig] = useState(false);
+    
+    // Sharing state
+    const [shareEmail, setShareEmail] = useState('');
+    const [shareRole, setShareRole] = useState<'reader'|'writer'>('reader');
+    const [isSharing, setIsSharing] = useState(false);
+    const [shareMessage, setShareMessage] = useState<{type: 'success'|'error', text: string} | null>(null);
+
+    // Connecting state
+    const [connectLink, setConnectLink] = useState('');
 
     const resetClientId = () => {
         if(confirm("Reset all settings?")) {
             localStorage.clear();
             window.location.reload();
         }
+    };
+
+    const handleShare = async () => {
+        if (!shareEmail || !shareEmail.includes('@')) {
+            setShareMessage({ type: 'error', text: 'Enter a valid email' });
+            return;
+        }
+        if (!driveFileId) return;
+
+        setIsSharing(true);
+        setShareMessage(null);
+        try {
+            await shareDriveFile(driveFileId, shareEmail, shareRole);
+            setShareMessage({ type: 'success', text: `Shared with ${shareEmail}` });
+            setShareEmail('');
+        } catch (err: unknown) {
+            const errorMessage = err instanceof Error ? err.message : 'Failed to share';
+            setShareMessage({ type: 'error', text: errorMessage });
+        } finally {
+            setIsSharing(false);
+        }
+    };
+
+    const handleConnect = () => {
+        if (!connectLink.trim()) return;
+        connectSharedFile(connectLink);
     };
 
     if (!isOpen) return null;
@@ -43,7 +89,9 @@ export default function SettingsModal({
                      <Cloud size={16} className="text-blue-500"/>
                      <h3 className="font-medium text-gray-800">Google Backup</h3>
                  </div>
-                 <p className="text-xs text-gray-500 mb-3">Sync your data to a folder named "{FOLDER_NAME}" in your Google Drive.</p>
+                 {!isSharedFile && (
+                     <p className="text-xs text-gray-500 mb-3">Sync your data to a folder named "{FOLDER_NAME}" in your Google Drive.</p>
+                 )}
                  
                  {!isAuthenticated ? (
                      <div className="space-y-2">
@@ -63,10 +111,100 @@ export default function SettingsModal({
                              Connect Google Drive
                          </button>
                      </div>
+                 ) : isSharedFile ? (
+                     <div className="space-y-2">
+                         <div className="flex justify-between items-center bg-violet-50 p-2 rounded border border-violet-100">
+                             <div className="flex items-center gap-2">
+                                 <Users size={14} className="text-violet-600"/>
+                                 <span className="text-xs text-violet-700 font-medium">Connected to Shared Data</span>
+                             </div>
+                             <button onClick={disconnectSharedFile} className="text-xs text-red-500 font-medium">Disconnect</button>
+                         </div>
+                         <div className="text-xs text-gray-500 px-1">
+                             Permission: <span className="font-semibold text-gray-700">{isSharedFileReadOnly ? 'Read Only' : 'Read & Write'}</span>
+                         </div>
+                     </div>
                  ) : (
                      <div className="flex justify-between items-center bg-green-50 p-2 rounded border border-green-100">
                          <span className="text-xs text-green-700 font-medium">Synced</span>
                          <button onClick={onLogout} className="text-xs text-red-500 font-medium">Disconnect</button>
+                     </div>
+                 )}
+             </div>
+
+             {/* Sharing & Connecting Section */}
+             <div className="bg-white p-3 rounded-lg border border-gray-100 mb-3 shadow-sm space-y-4">
+                 
+                 {/* Share Form (Only for own data) */}
+                 {!isSharedFile && isAuthenticated && driveFileId && (
+                     <div className="space-y-2 border-b border-slate-100 pb-3">
+                         <div className="flex items-center gap-2 mb-1">
+                             <Share2 size={16} className="text-rose-500"/>
+                             <h3 className="font-medium text-gray-800">Share Data</h3>
+                         </div>
+                         <p className="text-xs text-gray-500">Allow another user to sync with your data.</p>
+                         
+                         <input 
+                            type="email" 
+                            placeholder="Enter their Google email address" 
+                            className="w-full text-xs p-2 border rounded"
+                            value={shareEmail}
+                            onChange={(e) => setShareEmail(e.target.value)}
+                         />
+                         <div className="flex gap-2">
+                             <select 
+                                 className="flex-1 text-xs p-2 border rounded bg-white text-gray-700"
+                                 value={shareRole}
+                                 onChange={(e) => setShareRole(e.target.value as 'reader'|'writer')}
+                             >
+                                 <option value="reader">Read Only</option>
+                                 <option value="writer">Read & Write</option>
+                             </select>
+                             <button 
+                                 onClick={handleShare}
+                                 disabled={isSharing || !shareEmail}
+                                 className="flex-1 bg-slate-800 text-white py-2 rounded text-xs font-bold hover:bg-slate-700 disabled:opacity-50 transition-colors"
+                             >
+                                 {isSharing ? 'Sharing...' : 'Send Invite'}
+                             </button>
+                         </div>
+                         {shareMessage && (
+                             <div className={`flex items-center gap-1 text-xs mt-1 ${shareMessage.type === 'success' ? 'text-green-600' : 'text-red-500'}`}>
+                                 {shareMessage.type === 'success' ? <CheckCircle size={12}/> : <AlertCircle size={12}/>}
+                                 {shareMessage.text}
+                             </div>
+                         )}
+                         <div className="text-[10px] text-gray-400 mt-2 bg-slate-50 p-2 rounded">
+                            Share ID (for them to paste): <br/><span className="font-mono text-gray-600 break-all">{driveFileId}</span>
+                         </div>
+                     </div>
+                 )}
+
+                 {/* Connect Form */}
+                 {!isSharedFile && (
+                     <div className="space-y-2">
+                         <div className="flex items-center gap-2 mb-1">
+                             <LinkIcon size={16} className="text-indigo-500"/>
+                             <h3 className="font-medium text-gray-800">Connect Shared Data</h3>
+                         </div>
+                         <p className="text-xs text-gray-500">Paste a Google Drive link or Share ID provided by someone else.</p>
+                         
+                         <div className="flex gap-2">
+                             <input 
+                                type="text" 
+                                placeholder="Paste link or ID here..." 
+                                className="flex-[2] text-xs p-2 border rounded"
+                                value={connectLink}
+                                onChange={(e) => setConnectLink(e.target.value)}
+                             />
+                             <button 
+                                 onClick={handleConnect}
+                                 disabled={!connectLink}
+                                 className="flex-1 bg-indigo-500 text-white py-2 rounded text-xs font-bold hover:bg-indigo-600 disabled:opacity-50 transition-colors"
+                             >
+                                 Connect
+                             </button>
+                         </div>
                      </div>
                  )}
              </div>

--- a/src/hooks/useGoogleSync.integration.test.ts
+++ b/src/hooks/useGoogleSync.integration.test.ts
@@ -12,6 +12,8 @@ vi.mock('../services/googleService', () => ({
   revokeToken: vi.fn(() => Promise.resolve()),
   restoreGapiSession: vi.fn(),
   ensureValidToken: vi.fn(() => Promise.resolve()),
+  getSharedDriveFile: vi.fn(() => Promise.resolve({ id: 'shared-id', canEdit: true })),
+  shareDriveFile: vi.fn(() => Promise.resolve()),
 }));
 
 describe('useGoogleSync integration', () => {

--- a/src/hooks/useGoogleSync.ts
+++ b/src/hooks/useGoogleSync.ts
@@ -7,7 +7,8 @@ import {
   uploadDriveData, 
   fetchDriveDataContent,
   revokeToken,
-  restoreGapiSession
+  restoreGapiSession,
+  getSharedDriveFile
 } from '../services/googleService';
 import { mergeEvents, saveLocalEvents, parseAndMigrateData } from '../services/storageService';
 import { GOOGLE_CLIENT_ID, GOOGLE_SCOPES } from '../constants';
@@ -34,6 +35,8 @@ export function useGoogleSync({ events, setEvents }: UseGoogleSyncProps) {
   const [driveFileId, setDriveFileId] = useState<string | null>(null);
   const [syncState, setSyncState] = useState<SyncState>({ status: 'idle' });
   const [isApiInitialized, setIsApiInitialized] = useState(false);
+  const [isSharedFileReadOnly, setIsSharedFileReadOnly] = useState(false);
+  const [isSharedFile, setIsSharedFile] = useState(false);
   
   // Use Client ID from constants or fallback to local storage
   const [googleClientId, setGoogleClientId] = useState(() => {
@@ -81,10 +84,12 @@ export function useGoogleSync({ events, setEvents }: UseGoogleSyncProps) {
       setIsAuthenticated(false);
       setDriveFileId(null);
       setSyncState({ status: 'idle' });
+      setIsSharedFileReadOnly(false);
+      setIsSharedFile(false);
   }, []);
 
   // CORE SYNCHRONIZATION LOGIC
-  const performFullSync = useCallback(async (fileId: string) => {
+  const performFullSync = useCallback(async (fileId: string, isReadOnly: boolean = false) => {
     if (!fileId) return;
     setSyncState({ status: 'syncing' });
     try {
@@ -100,7 +105,7 @@ export function useGoogleSync({ events, setEvents }: UseGoogleSyncProps) {
         }
 
         const isRemoteDifferent = !eventsEqual(merged, remoteEvents);
-        if (isRemoteDifferent) {
+        if (isRemoteDifferent && !isReadOnly) {
              await uploadDriveData(fileId, merged);
         }
 
@@ -125,19 +130,42 @@ export function useGoogleSync({ events, setEvents }: UseGoogleSyncProps) {
             const token: GoogleToken = JSON.parse(storedTokenStr);
             
             // If we have a token, restore session immediately
-            // The ensureValidToken logic will handle refresh if it's expired during ensureDriveFileExists
             restoreGapiSession(token);
-            setTimeout(() => {
+            setTimeout(async () => {
                 setIsAuthenticated(true);
-                ensureDriveFileExists()
-                    .then(id => {
-                        setDriveFileId(id);
-                        performFullSync(id); 
-                    })
-                    .catch((err) => {
-                        console.error('Session restore failed', err);
-                        handleLogout();
-                    });
+                
+                try {
+                    const sharedId = localStorage.getItem('LUNA_SHARED_FILE_ID');
+                    let targetFileId = null;
+                    let isReadOnly = false;
+                    
+                    if (sharedId) {
+                        try {
+                            const sharedFile = await getSharedDriveFile(sharedId);
+                            targetFileId = sharedFile.id;
+                            isReadOnly = !sharedFile.canEdit;
+                            setIsSharedFileReadOnly(isReadOnly);
+                            setIsSharedFile(true);
+                        } catch (err) {
+                            console.warn("Could not access shared file, falling back to personal", err);
+                            localStorage.removeItem('LUNA_SHARED_FILE_ID');
+                            setIsSharedFile(false);
+                        }
+                    }
+                    
+                    if (!targetFileId) {
+                        targetFileId = await ensureDriveFileExists();
+                        setIsSharedFileReadOnly(false);
+                        setIsSharedFile(false);
+                        isReadOnly = false;
+                    }
+                    
+                    setDriveFileId(targetFileId);
+                    performFullSync(targetFileId, isReadOnly); 
+                } catch(err) {
+                    console.error('Session restore logic failed', err);
+                    handleLogout();
+                }
             }, 0);
         }
     } catch {
@@ -161,20 +189,64 @@ export function useGoogleSync({ events, setEvents }: UseGoogleSyncProps) {
     }
   };
 
+  const connectSharedFile = async (linkOrId: string) => {
+      // Extract ID from full link or just use the ID
+      const match = linkOrId.match(/[-\w]{25,}/);
+      const extractedId = match ? match[0] : linkOrId.trim();
+      
+      if (!extractedId) {
+          alert("Invalid link or File ID.");
+          return;
+      }
+      
+      localStorage.setItem('LUNA_SHARED_FILE_ID', extractedId);
+      
+      if (!isAuthenticated) {
+          await handleGoogleLogin();
+          return; // will redirect
+      }
+      
+      // If already authenticated, switch context immediately
+      try {
+          setSyncState({ status: 'syncing' });
+          const sharedFile = await getSharedDriveFile(extractedId);
+          setDriveFileId(sharedFile.id);
+          setIsSharedFileReadOnly(!sharedFile.canEdit);
+          setIsSharedFile(true);
+          performFullSync(sharedFile.id, !sharedFile.canEdit);
+          alert("Successfully connected to shared file!");
+      } catch (err) {
+          console.error("Failed to connect to shared file", err);
+          alert("Could not access the shared file. Ensure you have permission.");
+          setSyncState({ status: 'error' });
+          localStorage.removeItem('LUNA_SHARED_FILE_ID');
+          setIsSharedFile(false);
+      }
+  };
+
+  const disconnectSharedFile = () => {
+      localStorage.removeItem('LUNA_SHARED_FILE_ID');
+      setIsSharedFile(false);
+      setIsSharedFileReadOnly(false);
+      setDriveFileId(null);
+      // Trigger a reload to re-initialize with the personal file
+      window.location.reload();
+  };
+
   // Trigger Sync on Window Focus
   useEffect(() => {
       const onFocus = () => {
           if (isAuthenticated && driveFileId && syncState.status !== 'syncing') {
-              performFullSync(driveFileId);
+              performFullSync(driveFileId, isSharedFileReadOnly);
           }
       };
       window.addEventListener('focus', onFocus);
       return () => window.removeEventListener('focus', onFocus);
-  }, [isAuthenticated, driveFileId, syncState.status, performFullSync]);
+  }, [isAuthenticated, driveFileId, syncState.status, performFullSync, isSharedFileReadOnly]);
 
   // Debounced Auto-Save
   useEffect(() => {
-    if (!isAuthenticated || !driveFileId) return;
+    if (!isAuthenticated || !driveFileId || isSharedFileReadOnly) return;
     if (syncState.status === 'success' && Date.now() - (syncState.lastSynced?.getTime() || 0) < 2000) return;
 
     const timeoutId = setTimeout(async () => {
@@ -193,7 +265,7 @@ export function useGoogleSync({ events, setEvents }: UseGoogleSyncProps) {
     }, 2000); 
 
     return () => clearTimeout(timeoutId);
-  }, [events, isAuthenticated, driveFileId, handleLogout, syncState.status, syncState.lastSynced]);
+  }, [events, isAuthenticated, driveFileId, handleLogout, syncState.status, syncState.lastSynced, isSharedFileReadOnly]);
 
   return {
     isAuthenticated,
@@ -203,6 +275,10 @@ export function useGoogleSync({ events, setEvents }: UseGoogleSyncProps) {
     setGoogleClientId,
     handleGoogleLogin,
     handleLogout,
-    performFullSync
+    performFullSync,
+    connectSharedFile,
+    disconnectSharedFile,
+    isSharedFile,
+    isSharedFileReadOnly
   };
 }

--- a/src/services/googleService.ts
+++ b/src/services/googleService.ts
@@ -18,6 +18,9 @@ interface GapiClient {
         create: (params: Record<string, unknown>) => Promise<GapiFileResult<{ id: string }>>;
         get: (params: Record<string, unknown>) => Promise<GapiFileResult<unknown>>;
       };
+      permissions: {
+        create: (params: Record<string, unknown>) => Promise<GapiFileResult<unknown>>;
+      };
     };
   };
 }
@@ -261,6 +264,43 @@ export const fetchDriveDataContent = async (fileId: string): Promise<unknown> =>
         throw error;
     }
 }
+
+export const shareDriveFile = async (fileId: string, email: string, role: 'reader' | 'writer'): Promise<void> => {
+    await ensureValidToken();
+    try {
+        await window.gapi.client.drive.permissions.create({
+            fileId: fileId,
+            sendNotificationEmail: true,
+            resource: {
+                type: 'user',
+                role: role,
+                emailAddress: email
+            }
+        });
+    } catch (error) {
+        console.error("Share Drive File Error", error);
+        throw error;
+    }
+};
+
+export const getSharedDriveFile = async (fileId: string): Promise<{ id: string; canEdit: boolean }> => {
+    await ensureValidToken();
+    try {
+        const response = await window.gapi.client.drive.files.get({
+            fileId: fileId,
+            fields: 'id, capabilities'
+        });
+        
+        const file = response.result as { id: string; capabilities?: { canEdit?: boolean } };
+        return {
+            id: file.id,
+            canEdit: !!file.capabilities?.canEdit
+        };
+    } catch (error) {
+        console.error("Get Shared Drive File Error", error);
+        throw error;
+    }
+};
 
 export const revokeToken = async () => {
     try {


### PR DESCRIPTION
## Summary
Implement a feature allowing a user to share their LunaFlow data via Google Drive with another user. The second user can connect to the shared file to view or edit the data using the same sync logic.

## Changes
- **googleService.ts**: Added `shareDriveFile` and `getSharedDriveFile` to manage permissions and shared access.
- **useGoogleSync.ts**: Added logic to resolve shared file IDs from local storage and handle read-only synchronization for shared files.
- **SettingsModal.tsx**: Added UI for sharing (email input, role selection) and connecting (pasting link/ID).
- **Header.tsx & CalendarApp.tsx**: Updated prop drilling for sharing functions.
- **useGoogleSync.integration.test.ts**: Updated mocks to support the new features.

## Testing
- Verified with unit and integration tests (`npm run test`).
- Verified linting (`npm run lint`) and build (`npm run build`).